### PR TITLE
running blaeu-dockerimage as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ CMD ["--help"]
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt && \
     rm -rf requirements.txt
+RUN groupadd -g 10001 blaeu && \
+    useradd -u 10000 -g blaeu blaeu
+USER blaeu:blaeu
 CMD ["blaeu-reach","--help"]
 # END

--- a/README.md
+++ b/README.md
@@ -16,24 +16,26 @@ To get it, go to [https://atlas.ripe.net/keys/](https://atlas.ripe.net/keys/), a
 
 Once you get it, you can use the following example:
 
-    mkdir -p ~/.atlas
-    echo "MYAPIKEY" > ~/.atlas/auth
+Store securely your api key in the variable `${ATLASAUTH}` for later une as an envvar in the container
+
+    read -r -s -p "API KEY ? " ATLASAUTH
+    API KEY ? # enter your api key here
 
 ### Lite Image
 
 The lite (and main) image is python-based and ready-to-use.
 Just run :
 
-    sudo docker run -v $HOME/.atlas:/root/.atlas:ro packettoobig/blaeu
+    sudo docker run --env ATLASAUTH=${ATLASAUTH} packettoobig/blaeu
 
 It will display the `blaeu-reach` help menu.
 
 Here are some examples of what you can do :
 
-    sudo docker run -v $HOME/.atlas:/root/.atlas:ro packettoobig/blaeu blaeu-reach 1.1.1.1
-    sudo docker run -v $HOME/.atlas:/root/.atlas:ro packettoobig/blaeu blaeu-traceroute 2600::
-    sudo docker run -v $HOME/.atlas:/root/.atlas:ro packettoobig/blaeu blaeu-resolve gnu.org
-    sudo docker run -v $HOME/.atlas:/root/.atlas:ro packettoobig/blaeu blaeu-cert www.eff.org
+    sudo docker run --env ATLASAUTH=${ATLASAUTH} packettoobig/blaeu blaeu-reach 1.1.1.1
+    sudo docker run --env ATLASAUTH=${ATLASAUTH} packettoobig/blaeu blaeu-traceroute 2600::
+    sudo docker run --env ATLASAUTH=${ATLASAUTH} packettoobig/blaeu blaeu-resolve gnu.org
+    sudo docker run --env ATLASAUTH=${ATLASAUTH} packettoobig/blaeu blaeu-cert www.eff.org
 
 ### Full Image
 


### PR DESCRIPTION
Hi, 

running container as root isn't best practice see <https://docs.docker.com/develop/develop-images/instructions/#user>.

Running as non privileged user [decreases the risk that container -> host privilege escalation could occur](https://github.com/dnaprawa/dockerfile-best-practices#run-as-a-non-root-user).

Since <https://framagit.org/bortzmeyer/blaeu/-/merge_requests/9> merged for blaeu 1.1.10 <https://pypi.org/project/blaeu/1.1.10/> blaeu accepts the use of envvar to consume the RIPE Atlas API key

I suggest 

- add a non privileged `USER` directive to `Dockerfile`
- using `--env` instead of `--volume` to use the api key at execution

README is updated accordingly.
